### PR TITLE
refactor(config): centralise et simplifie les imports avec des alias

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,13 +1,13 @@
 import { Component, OnInit } from '@angular/core';
-import { NavbarComponent } from './shared/ui/navbar/navbar.component';
-import { HeroComponent } from './features/public/hero/hero.component';
-import { AboutComponent } from './features/public/about/about.component';
-import { StacksComponent } from './features/public/stacks/stacks.component';
-import { ProjectComponent } from './features/public/project/project.component';
-import { ContactComponent } from './features/public/contact/contact.component';
+import { NavbarComponent } from '@shared/ui/navbar/navbar.component';
+import { HeroComponent } from '@feat/public/hero/hero.component';
+import { AboutComponent } from '@feat/public/about/about.component';
+import { StacksComponent } from '@feat/public/stacks/stacks.component';
+import { ProjectComponent } from '@feat/public/project/project.component';
+import { ContactComponent } from '@feat/public/contact/contact.component';
 import emailjs from '@emailjs/browser';
-import { FooterComponent } from './shared/ui/footer/footer.component';
-import { environment } from '../environments/environment';
+import { FooterComponent } from '@shared/ui/footer/footer.component';
+import { environment } from '@environments/environment';
 
 @Component({
   selector: 'app-root',

--- a/src/app/core/services/toast.service.ts
+++ b/src/app/core/services/toast.service.ts
@@ -1,5 +1,5 @@
 import { effect, Injectable, signal } from '@angular/core';
-import { Toast } from '../../shared/ui/toast/toast.interface';
+import { Toast } from '@shared/ui/toast/toast.interface';
 
 @Injectable({ providedIn: 'root' })
 export class ToastService {

--- a/src/app/features/public/about/service/about.service.ts
+++ b/src/app/features/public/about/service/about.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable, signal } from '@angular/core';
 import { About } from '../interface/about.interface';
-import { DataService } from '../../../../core/services/data.service';
+import { DataService } from '@core/services/data.service';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/features/public/contact/contact.component.ts
+++ b/src/app/features/public/contact/contact.component.ts
@@ -3,9 +3,9 @@ import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ContactCard, ContactCardGroup } from './interface/contact.interface';
 import { ContactService } from './service/contact.service';
-import { ToastService } from '../../../core/services/toast.service';
-import { ToastComponent } from '../../../shared/ui/toast/toast.component';
-import { ButtonComponent } from '../../../shared/ui/button/button.component';
+import { ToastService } from '@core/services/toast.service';
+import { ToastComponent } from '@shared/ui/toast/toast.component';
+import { ButtonComponent } from '@shared/ui/button/button.component';
 
 @Component({
   selector: 'app-contact',

--- a/src/app/features/public/contact/service/contact.service.ts
+++ b/src/app/features/public/contact/service/contact.service.ts
@@ -1,11 +1,11 @@
 import { inject, Injectable, signal } from '@angular/core';
 import { ContactCard, ContactCardGroup, ContactForm } from '../interface/contact.interface';
 import { Observable, catchError, from, map, tap } from 'rxjs';
-import { DataService } from '../../../../core/services/data.service';
+import { DataService } from '@core/services/data.service';
 
 // Import EmailJS
 import emailjs from '@emailjs/browser';
-import { environment } from '../../../../../environments/environment';
+import { environment } from '@environments/environment';
 
 interface Contact {
   cards: ContactCard[];

--- a/src/app/features/public/hero/hero.component.ts
+++ b/src/app/features/public/hero/hero.component.ts
@@ -1,7 +1,7 @@
 import { Component, computed, inject, OnInit } from '@angular/core';
-import { ButtonComponent } from '../../../shared/ui/button/button.component';
+import { ButtonComponent } from '@shared/ui/button/button.component';
 import { NgOptimizedImage } from '@angular/common';
-import { ScrollService } from '../../../core/services/scroll.service';
+import { ScrollService } from '@core/services/scroll.service';
 import { HeroService } from './service/hero.service';
 
 @Component({

--- a/src/app/features/public/hero/service/hero.service.ts
+++ b/src/app/features/public/hero/service/hero.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, signal, inject } from '@angular/core';
 import { Hero } from '../interface/hero.interface';
-import { DataService } from '../../../../core/services/data.service';
+import { DataService } from '@core/services/data.service';
 
 @Injectable({ providedIn: 'root' })
 export class HeroService {

--- a/src/app/features/public/project/service/project.service.ts
+++ b/src/app/features/public/project/service/project.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable, signal } from '@angular/core';
 import { Project } from '../interface/project.interface';
-import { DataService } from '../../../../core/services/data.service';
+import { DataService } from '@core/services/data.service';
 
 @Injectable({ providedIn: 'root' })
 export class ProjectService {

--- a/src/app/features/public/stacks/service/stacks.service.ts
+++ b/src/app/features/public/stacks/service/stacks.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { Category, HardSkills, SoftSkills } from '../interface/stacks.interface';
-import { DataService } from '../../../../core/services/data.service';
+import { DataService } from '@core/services/data.service';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/shared/ui/badge/badge.component.ts
+++ b/src/app/shared/ui/badge/badge.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, signal } from '@angular/core';
-import { BadgeDirective } from '../../../core/directives/badge.directive';
-import { BadgeDatePipe } from '../../../core/pipes/badge.pipe';
+import { BadgeDirective } from '@core/directives/badge.directive';
+import { BadgeDatePipe } from '@core/pipes/badge.pipe';
 
 @Component({
   selector: 'app-badge',

--- a/src/app/shared/ui/navbar/navbar.component.ts
+++ b/src/app/shared/ui/navbar/navbar.component.ts
@@ -3,9 +3,9 @@ import { inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { NavigationItem } from './navigation-item.interface';
-import { ThemeService } from '../../../core/services/theme.service';
+import { ThemeService } from '@core/services/theme.service';
 import { NAVIGATION_ITEMS } from './navigation-items.constant';
-import { ScrollService } from '../../../core/services/scroll.service';
+import { ScrollService } from '@core/services/scroll.service';
 import { BadgeComponent } from '../badge/badge.component';
 
 @Component({

--- a/src/app/shared/ui/toast/toast.component.ts
+++ b/src/app/shared/ui/toast/toast.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, inject } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
-import { ToastService } from '../../../core/services/toast.service';
+import { ToastService } from '@core/services/toast.service';
 
 @Component({
   selector: 'app-toast',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,15 @@
     "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
-    "module": "ES2022"
+    "module": "ES2022",
+    "baseUrl": "./",
+    "paths": {
+      "@environments/*": ["src/environments/*"],
+      "@app/*": ["src/app/*"],
+      "@core/*": ["src/app/core/*"],
+      "@feat/*": ["src/app/features/*"],
+      "@shared/*": ["src/app/shared/*"],
+    }
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
- Ajoute des alias dans le `tsconfig.json` pour uniformiser les imports.
- Réorganise les chemins des modules pour utiliser les alias, améliorant la lisibilité et la maintenance.