### PR TITLE
chore(config): Supprime les en-têtes CSP du projet

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,9 +5,6 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
-  # Add Content Security Policy headers
-  add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.emailjs.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.emailjs.com; img-src 'self' data:; font-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'";
-
   location / {
     try_files $uri $uri/ /index.html;
   }

--- a/src/index.html
+++ b/src/index.html
@@ -5,10 +5,6 @@
     <title>NÉDELLEC Julien | Portfolio</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://cdn.emailjs.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.emailjs.com; img-src 'self' data:; font-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self';"
-    />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   </head>
   <body>


### PR DESCRIPTION
- Retire les en-têtes Content Security Policy du fichier `nginx.conf` et des métadonnées HTML.
- Permet une gestion plus flexible des politiques de sécurité à l'avenir.