### PR TITLE
refactor(component:hero): Simplifie la logique de téléchargement du CV

### DIFF
--- a/src/app/features/public/hero/hero.component.ts
+++ b/src/app/features/public/hero/hero.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ButtonComponent } from '@shared/ui/button/button.component';
 import { NgOptimizedImage } from '@angular/common';
 import { ScrollService } from '@core/services/scroll.service';
@@ -18,13 +18,11 @@ export class HeroComponent {
   private readonly metricsService = inject(MetricsService);
 
   readonly hero: Hero = DATA_HERO;
-  readonly cvPath = 'docs/CV_DEVELOPPEUR_ANGULAR_NEDELLEC_JULIEN.pdf';
-  readonly downloadCvClick = signal(false);
 
   downloadCV(): void {
     this.metricsService.trackCvClick('static-hero').subscribe({
       next: () => {
-        const fileUrl = this.fileUrlService.getFileUrl(this.cvPath);
+        const fileUrl = this.fileUrlService.getFileUrl('/cv');
         window.open(fileUrl, '_blank');
       },
       error: (err) => {


### PR DESCRIPTION
- Remplace le chemin statique du fichier CV par une URL générique `/cv` dans `FileUrlService`.
- Supprime les propriétés inutilisées `cvPath` et `downloadCvClick` pour alléger le code.