### PR TITLE
refactor(service:api): Ajoute des méthodes basées sur les signals

### DIFF
--- a/src/app/core/http/http.adapter.ts
+++ b/src/app/core/http/http.adapter.ts
@@ -1,40 +1,45 @@
+import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '@environments/environment';
+import { ResourceSignals, createResourceSignal } from '../utils/signal-utils';
 
 @Injectable({ providedIn: 'root' })
 export class HttpAdapterService {
   private readonly http: HttpClient = inject(HttpClient);
   private readonly baseUrl: string = environment.apiUrl;
 
+  private resolveUrl(path: string): string {
+    return `${this.baseUrl}${path.startsWith('/') ? path : '/' + path}`;
+  }
+
   get<T>(path: string, params?: HttpParams): Observable<T> {
-    return this.http.get<T>(`${this.baseUrl}${path}`, {
+    return this.http.get<T>(this.resolveUrl(path), {
       params,
       withCredentials: true,
     });
   }
 
   post<T>(path: string, body: unknown): Observable<T> {
-    return this.http.post<T>(`${this.baseUrl}${path}`, body, {
+    return this.http.post<T>(this.resolveUrl(path), body, {
       withCredentials: true,
     });
   }
 
   put<T>(path: string, body: unknown): Observable<T> {
-    return this.http.put<T>(`${this.baseUrl}${path}`, body, {
+    return this.http.put<T>(this.resolveUrl(path), body, {
       withCredentials: true,
     });
   }
 
   patch<T>(path: string, body: unknown): Observable<T> {
-    return this.http.patch<T>(`${this.baseUrl}${path}`, body, {
+    return this.http.patch<T>(this.resolveUrl(path), body, {
       withCredentials: true,
     });
   }
 
   delete<T>(path: string): Observable<T> {
-    return this.http.delete<T>(`${this.baseUrl}${path}`, {
+    return this.http.delete<T>(this.resolveUrl(path), {
       withCredentials: true,
     });
   }
@@ -46,7 +51,7 @@ export class HttpAdapterService {
       formData.append(key, extraData[key]);
     }
 
-    return this.http.post<T>(`${this.baseUrl}${path}`, formData, {
+    return this.http.post<T>(this.resolveUrl(path), formData, {
       withCredentials: true,
     });
   }
@@ -58,15 +63,49 @@ export class HttpAdapterService {
       formData.append(key, extraData[key]);
     }
 
-    return this.http.patch<T>(`${this.baseUrl}${path}`, formData, {
+    return this.http.patch<T>(this.resolveUrl(path), formData, {
       withCredentials: true,
     });
   }
 
   getBinary(path: string): Observable<Blob> {
-    return this.http.get(`${this.baseUrl}${path}`, {
+    return this.http.get(this.resolveUrl(path), {
       responseType: 'blob',
       withCredentials: true,
     });
+  }
+
+  // Signal-based alternatives
+
+  getWithSignal<T>(path: string, params?: HttpParams): ResourceSignals<T> {
+    return createResourceSignal(() => this.get<T>(path, params));
+  }
+
+  postWithSignal<T>(path: string, body: unknown): ResourceSignals<T> {
+    return createResourceSignal(() => this.post<T>(path, body));
+  }
+
+  putWithSignal<T>(path: string, body: unknown): ResourceSignals<T> {
+    return createResourceSignal(() => this.put<T>(path, body));
+  }
+
+  patchWithSignal<T>(path: string, body: unknown): ResourceSignals<T> {
+    return createResourceSignal(() => this.patch<T>(path, body));
+  }
+
+  deleteWithSignal<T>(path: string): ResourceSignals<T> {
+    return createResourceSignal(() => this.delete<T>(path));
+  }
+
+  uploadFileWithSignal<T>(path: string, file: File, extraData: Record<string, string>): ResourceSignals<T> {
+    return createResourceSignal(() => this.uploadFile<T>(path, file, extraData));
+  }
+
+  patchFileWithSignal<T>(path: string, file: File, extraData: Record<string, string> = {}): ResourceSignals<T> {
+    return createResourceSignal(() => this.patchFile<T>(path, file, extraData));
+  }
+
+  getBinaryWithSignal(path: string): ResourceSignals<Blob> {
+    return createResourceSignal(() => this.getBinary(path));
   }
 }

--- a/src/app/core/utils/signal-utils.ts
+++ b/src/app/core/utils/signal-utils.ts
@@ -1,0 +1,142 @@
+import { computed, signal, type Signal } from '@angular/core';
+import { Observable, catchError, finalize, of, tap } from 'rxjs';
+
+export interface ResourceSignals<T> {
+  data: Signal<T | null>;
+  loading: Signal<boolean>;
+  error: Signal<Error | null>;
+  refresh: () => void;
+  setData: (data: T) => void;
+  setError: (error: Error) => void;
+  setLoading: (loading: boolean) => void;
+}
+
+export function createResourceSignal<T>(
+  fetcher: () => Observable<T>,
+  initialData: T | null = null
+): ResourceSignals<T> {
+  const dataSignal = signal<T | null>(initialData);
+  const loadingSignal = signal<boolean>(false);
+  const errorSignal = signal<Error | null>(null);
+
+  const fetchData = () => {
+    loadingSignal.set(true);
+    errorSignal.set(null);
+
+    return fetcher().pipe(
+      tap((result) => {
+        dataSignal.set(result);
+      }),
+      catchError((error: Error) => {
+        errorSignal.set(error);
+        return of(null);
+      }),
+      finalize(() => {
+        loadingSignal.set(false);
+      })
+    );
+  };
+
+  const refresh = () => {
+    fetchData().subscribe();
+  };
+
+  if (initialData === null) {
+    refresh();
+  }
+
+  return {
+    data: dataSignal.asReadonly(),
+    loading: loadingSignal.asReadonly(),
+    error: errorSignal.asReadonly(),
+    refresh,
+    setData: (data: T) => dataSignal.set(data),
+    setError: (error: Error) => errorSignal.set(error),
+    setLoading: (loading: boolean) => loadingSignal.set(loading),
+  };
+}
+
+export interface PaginatedResourceSignals<T> extends ResourceSignals<T[]> {
+  page: Signal<number>;
+  totalPages: Signal<number>;
+  hasMore: Signal<boolean>;
+  nextPage: () => void;
+  prevPage: () => void;
+  goToPage: (page: number) => void;
+}
+
+export function createPaginatedResourceSignal<T, R = { items: T[]; totalPages: number }>(
+  fetcher: (page: number) => Observable<R>,
+  getItems: (response: R) => T[],
+  getTotalPages: (response: R) => number,
+  initialPage = 1
+): PaginatedResourceSignals<T> {
+  // Create signals
+  const dataSignal = signal<T[]>([]);
+  const loadingSignal = signal<boolean>(false);
+  const errorSignal = signal<Error | null>(null);
+  const pageSignal = signal<number>(initialPage);
+  const totalPagesSignal = signal<number>(1);
+  const hasMoreSignal = computed(() => pageSignal() < totalPagesSignal());
+
+  const fetchPage = (page: number) => {
+    loadingSignal.set(true);
+    errorSignal.set(null);
+
+    return fetcher(page).pipe(
+      tap((response) => {
+        dataSignal.set(getItems(response));
+        totalPagesSignal.set(getTotalPages(response));
+      }),
+      catchError((error: Error) => {
+        errorSignal.set(error);
+        return of(null as unknown as R);
+      }),
+      finalize(() => {
+        loadingSignal.set(false);
+      })
+    );
+  };
+
+  const goToPage = (page: number) => {
+    if (page < 1 || page > totalPagesSignal()) {
+      return;
+    }
+    pageSignal.set(page);
+    fetchPage(page).subscribe();
+  };
+
+  const nextPage = () => {
+    if (hasMoreSignal()) {
+      goToPage(pageSignal() + 1);
+    }
+  };
+
+  const prevPage = () => {
+    if (pageSignal() > 1) {
+      goToPage(pageSignal() - 1);
+    }
+  };
+
+  const refresh = () => {
+    fetchPage(pageSignal()).subscribe();
+  };
+
+  refresh();
+
+  return {
+    data: dataSignal.asReadonly(),
+    loading: loadingSignal.asReadonly(),
+    error: errorSignal.asReadonly(),
+    page: pageSignal.asReadonly(),
+    totalPages: totalPagesSignal.asReadonly(),
+    hasMore: hasMoreSignal,
+    refresh,
+    nextPage,
+    prevPage,
+    goToPage,
+    setData: (data: T[]) => dataSignal.set(data),
+    setError: (error: Error) => errorSignal.set(error),
+    setLoading: (loading: boolean) => loadingSignal.set(loading),
+  };
+}

--- a/src/app/features/admin/cv-upload/cv-upload.component.ts
+++ b/src/app/features/admin/cv-upload/cv-upload.component.ts
@@ -8,6 +8,7 @@ import { ApiErrorOrNull, ApiErrorResponse, FileUploadResponse } from '@core/mode
 
 @Component({
   selector: 'app-cv-upload',
+  standalone: true,
   imports: [CommonModule, NgOptimizedImage],
   templateUrl: './cv-upload.component.html',
 })

--- a/src/app/features/public/hero/hero.component.ts
+++ b/src/app/features/public/hero/hero.component.ts
@@ -9,6 +9,7 @@ import { Hero } from '@feat/public/hero/interface/hero.interface';
 
 @Component({
   selector: 'app-hero',
+  standalone: true,
   imports: [ButtonComponent, NgOptimizedImage],
   templateUrl: './hero.component.html',
 })
@@ -20,6 +21,7 @@ export class HeroComponent {
   readonly hero: Hero = DATA_HERO;
 
   downloadCV(): void {
+    // Track CV click and open the file
     this.metricsService.trackCvClick('static-hero').subscribe({
       next: () => {
         const fileUrl = this.fileUrlService.getFileUrl('/cv');
@@ -29,6 +31,10 @@ export class HeroComponent {
         console.error(err);
       },
     });
+
+    // We can also access the cvClickCount signal directly if needed
+    // const currentClicks = this.metricsService.cvClickCount();
+    // console.log(`CV has been clicked ${currentClicks} times`);
   }
 
   scrollToSection(fragment: string): Promise<void> {


### PR DESCRIPTION
- Introduit des variantes basées sur les signals pour les méthodes HTTP dans `HttpAdapterService`.
- Centralise la résolution des URL via une méthode dédiée `resolveUrl` pour améliorer la maintenabilité.