### PR TITLE
refactor(config:build): Génère et copie `environment.ts` pour le build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,14 @@ COPY . .
 ARG API_URL
 ENV API_URL=$API_URL
 
-# ✅ Corrigé : écriture dans environment.prod.ts uniquement
+# ✅ Corrigé : écriture dans environment.ts et environment.prod.ts
 RUN mkdir -p src/environments && \
-  echo "export const environment = {" > src/environments/environment.prod.ts && \
-  echo "  production: true," >> src/environments/environment.prod.ts && \
-  echo "  apiUrl: '${API_URL}'" >> src/environments/environment.prod.ts && \
-  echo "};" >> src/environments/environment.prod.ts && \
-  cat src/environments/environment.prod.ts
+  echo "export const environment = {" > src/environments/environment.ts && \
+  echo "  production: true," >> src/environments/environment.ts && \
+  echo "  apiUrl: '${API_URL}'" >> src/environments/environment.ts && \
+  echo "};" >> src/environments/environment.ts && \
+  cp src/environments/environment.ts src/environments/environment.prod.ts && \
+  cat src/environments/environment.ts
 
 # Build Angular en mode production
 RUN pnpm run build --configuration=production


### PR DESCRIPTION
- Crée `environment.ts` dans le Dockerfile, puis le copie en tant que `environment.prod.ts`.
- Assure un alignement entre les fichiers d'environnement pour les builds en production.