### PR TITLE
refactor(service:api): Utilise `environment.prod` dans `HttpAdapter'

### DIFF
--- a/src/app/core/http/http.adapter.ts
+++ b/src/app/core/http/http.adapter.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { environment } from '@environments/environment';
+import { environment } from '@environments/environment.prod';
 
 @Injectable({ providedIn: 'root' })
 export class HttpAdapterService {


### PR DESCRIPTION
- Remplace l'import de l'environnement par `environment.prod` pour aligner sur le fichier de configuration de production.
- Facilite la gestion des environnements et réduit les risques d'erreurs en production.