### PR TITLE
refactor(config:build): Ajuste la politique Content-Security-Policy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -5,7 +5,7 @@
   # 🔐 Headers de sécurité
   header {
     Strict-Transport-Security "max-age=31536000; includeSubDomains"
-    Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'"
+    Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"
     X-Frame-Options "SAMEORIGIN"
     X-Content-Type-Options "nosniff"
     Referrer-Policy "strict-origin-when-cross-origin"


### PR DESCRIPTION
- Supprime `unsafe-inline` de `style-src` pour renforcer la sécurité des styles intégrés.
- Simplifie la configuration des headers dans le fichier Caddyfile.