### PR TITLE
refactor(config:build): Ajoute `unsafe-hashes` dans `script-src` de la CSP

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,12 +2,11 @@
   root * /usr/share/caddy
   file_server
 
-  # 🔐 Headers de sécurité CSP adaptés à Angular
   header {
     Strict-Transport-Security "max-age=31536000; includeSubDomains"
     Content-Security-Policy "
       default-src 'self';
-      script-src 'self';
+      script-src 'self' 'unsafe-hashes';
       style-src 'self' 'unsafe-inline';
       object-src 'none';
       frame-ancestors 'self';


### PR DESCRIPTION
- Autorise l'utilisation de hashes sécurisés pour les scripts tout en maintenant un niveau de sécurité élevé.
- Met à jour la configuration du fichier Caddyfile pour refléter cette modification.