### PR TITLE
refactor(config:build): Ajoute `unsafe-inline` dans `script-src` de l…

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -6,7 +6,7 @@
     Strict-Transport-Security "max-age=31536000; includeSubDomains"
     Content-Security-Policy "
       default-src 'self';
-      script-src 'self' 'unsafe-hashes';
+      script-src 'self' 'unsafe-hashes' 'unsafe-inline';
       style-src 'self' 'unsafe-inline';
       object-src 'none';
       frame-ancestors 'self';


### PR DESCRIPTION
…a CSP

- Autorise les scripts inline pour des besoins spécifiques tout en respectant les autres directives de sécurité.
- Modifie la configuration du fichier Caddyfile pour inclure cette autorisation.