### PR TITLE
refactor(config:build): Simplifie les matchers pour les fichiers statics

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,11 +4,7 @@
 
   # Define static assets matcher - covers all static resources from the issue
   @staticAssets {
-    # Include all common static file extensions
-    path *.css *.js *.webp *.jpg *.jpeg *.png *.gif *.ico *.svg
-    path *.woff *.woff2 *.ttf *.eot *.pdf *.mp4 *.webm
-    # Also match specific paths from the issue if needed
-    path /chunk-* /main-* /polyfills-* /styles-* /images/*
+    path *.css *.js *.webp *.jpg *.jpeg *.png *.gif *.ico *.svg *.woff *.woff2 *.ttf *.eot *.pdf *.mp4 *.webm /chunk-* /main-* /polyfills-* /styles-* /images/*
   }
 
   # Define non-static assets matcher (everything else)


### PR DESCRIPTION
- Combine les extensions et chemins spécifiques en une seule déclaration `path` dans `@staticAssets`.
- Réduit les redondances dans la configuration du fichier Caddyfile.