### PR TITLE
refactor(config:build): Supprime les matchers et simplifie les headers dans Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,19 +2,13 @@
   root * /usr/share/caddy
   file_server
 
-  # Define static assets matcher - covers all static resources from the issue
+  # Matcher pour assets statiques
   @staticAssets {
-    path *.css *.js *.webp *.jpg *.jpeg *.png *.gif *.ico *.svg *.woff *.woff2 *.ttf *.eot *.pdf *.mp4 *.webm /chunk-* /main-* /polyfills-* /styles-* /images/*
+    path *.css *.js *.webp *.jpg *.jpeg *.png *.gif *.ico *.svg *.woff *.woff2 *.ttf *.eot *.pdf *.mp4 *.webm
   }
 
-  # Define non-static assets matcher (everything else)
-  @nonStaticAssets {
-    # Anything that doesn't match the static assets matcher
-    not @staticAssets
-  }
-
-  # Security headers for all responses
   header {
+    # Global security headers
     Strict-Transport-Security "max-age=31536000; includeSubDomains"
     Content-Security-Policy "
       default-src 'self';
@@ -31,15 +25,9 @@
     -Server
   }
 
-  # Cache headers for static assets (long-lived)
   header @staticAssets {
     Cache-Control "public, max-age=31536000, immutable"
     Vary "Accept-Encoding"
-  }
-
-  # Cache headers for non-static assets (shorter-lived)
-  header @nonStaticAssets {
-    Cache-Control "public, max-age=3600"
   }
 
   try_files {path} /index.html


### PR DESCRIPTION
- Élimine le matcher `@nonStaticAssets` et regroupe les règles de headers pour simplifier la configuration.
- Réorganise les commentaires pour une meilleure lisibilité du fichier.