### PR TITLE
refactor(config:build): Supprime `br` pour simplifier la configuration d'encodage

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,7 +1,7 @@
 :80 {
   root * /usr/share/caddy
   file_server
-  encode gzip zstd br
+  encode gzip zstd
 
   # Matcher pour assets statiques
   @staticAssets {


### PR DESCRIPTION
- Retire l'encodage `br` dans le fichier `Caddyfile`, laissant uniquement `gzip` et `zstd`.
- Simplifie la gestion des types d'encodages supportés par le serveur.