### PR TITLE
refactor(config:build): Met à jour le Caddyfile pour simplifier la co…

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -28,8 +28,13 @@ nedellec-julien.fr, www.nedellec-julien.fr {
     Vary "Accept-Encoding"
   }
 
-  # Disable trailing slash redirects
-  uri strip_suffix /
+  # Handle paths with or without trailing slashes
+  @notFile {
+    not file {
+      try_files {path} {path}/index.html
+    }
+  }
+  rewrite @notFile /index.html
 
-  try_files {path} /index.html
+  try_files {path} {path}/index.html /index.html
 }


### PR DESCRIPTION
…nfiguration

- Change le `root` vers `/usr/share/caddy` pour aligner avec les standards.
- Ajuste le matcher `@staticAssets` en supprimant les types de fichiers obsolètes.
- Simplifie la directive `Content-Security-Policy` pour réduire la complexité.