### PR TITLE
refactor(config:build): Simplifie la gestion des fichiers et des rout…

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,19 +1,16 @@
 nedellec-julien.fr, www.nedellec-julien.fr {
   root * /usr/share/caddy
-  file_server
   encode gzip zstd
   log {
     output stdout
     format json
   }
 
-  # Matcher pour assets statiques
   @staticAssets {
     path *.css *.js *.webp *.jpg *.jpeg *.png *.gif *.ico *.svg *.woff *.woff2 *.ttf *.eot *.pdf *.mp4 *.webm
   }
 
   header {
-    # Global security headers
     Strict-Transport-Security "max-age=31536000; includeSubDomains"
     Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; object-src 'none'; frame-ancestors 'self'; base-uri 'self'"
     X-Frame-Options "SAMEORIGIN"
@@ -28,13 +25,12 @@ nedellec-julien.fr, www.nedellec-julien.fr {
     Vary "Accept-Encoding"
   }
 
-  # Handle paths with or without trailing slashes
-  @notFile {
-    not file {
-      try_files {path} {path}/index.html
-    }
+  handle @staticAssets {
+    file_server
   }
-  rewrite @notFile /index.html
 
-  try_files {path} {path}/index.html /index.html
+  handle {
+    rewrite * /index.html
+    file_server
+  }
 }


### PR DESCRIPTION
…es dans le Caddyfile

- Regroupe les handlers et ajuste les directives `file_server` pour une gestion unifiée.
- Supprime les commentaires redondants et réorganise les sections pour une meilleure lisibilité.
- Simplifie la stratégie de réécriture et le traitement des fichiers non-existants avec `handle`.