### PR TITLE
refactor(config:build): Simplifie la configuration du Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,40 +1,9 @@
-nedellec-julien.fr, www.nedellec-julien.fr {
-  root * /usr/share/caddy
-  encode zstd gzip
+:80 {
+    root * /usr/share/caddy
+    encode zstd gzip
 
-  log {
-    output stdout
-    format json
-  }
+    auto_https off
 
-  # Cache long sur les fichiers statiques
-  @staticAssets {
-    path *.js *.css *.woff2 *.woff *.ttf *.svg *.webp *.png *.jpg *.jpeg *.ico *.pdf *.json *.txt
-  }
-
-  header {
-    Strict-Transport-Security "max-age=31536000; includeSubDomains"
-    Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https:; img-src 'self' data:; font-src 'self';"
-    X-Frame-Options "SAMEORIGIN"
-    X-Content-Type-Options "nosniff"
-    Referrer-Policy "strict-origin-when-cross-origin"
-    Permissions-Policy "geolocation=(), microphone=(), camera=()"
-    -Server
-  }
-
-  header @staticAssets {
-    Cache-Control "public, max-age=31536000, immutable"
-    Vary "Accept-Encoding"
-  }
-
-  # Serve les fichiers statiques
-  handle @staticAssets {
-    file_server
-  }
-
-  # Redirection vers index.html pour routes Angular
-  handle {
     try_files {path} /index.html
     file_server
-  }
 }


### PR DESCRIPTION
- Supprime les domaines et active `:80` avec `auto_https off` pour une configuration minimale.
- Retire les headers, le cache, et les stratégies de sécurité pour réduire la complexité.
- Conserve uniquement la logique `try_files` et `file_server` pour un routage simplifié.