### PR TITLE
refactor(config:build): Réorganise le Caddyfile et remet `auto_https …

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,8 +1,10 @@
+{
+    auto_https off
+}
+
 :80 {
     root * /usr/share/caddy
     encode zstd gzip
-
-    auto_https off
 
     try_files {path} /index.html
     file_server


### PR DESCRIPTION
…off` en global

- Déplace `auto_https off` dans le bloc global pour une configuration plus propre.
- Conserve les directives existantes avec `try_files` et `file_server`.